### PR TITLE
Adding Ollama, Streaming, & More

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,11 @@ dependencies = [
  "env_logger",
  "indicatif",
  "log",
+ "musli",
  "predicates",
  "reqwest",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -505,6 +507,20 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -869,6 +885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +940,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +986,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "musli"
+version = "0.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d1824ac6e17853c4eabc4d952122aecc1454c0e22bbfd3a44f43c1a46c1af3"
+dependencies = [
+ "itoa",
+ "loom",
+ "musli-core",
+ "ryu",
+ "serde",
+ "simdutf8",
+]
+
+[[package]]
+name = "musli-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89a1338c2da9f8cbf8b60c4e3edaab4eb0809d52fc2d7f69ac4da58d9050953"
+dependencies = [
+ "musli-macros",
+]
+
+[[package]]
+name = "musli-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6dea70dccfc68fd441c128bdaf31c454542676f750f095465640367fd94118"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1041,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -1333,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1562,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1590,6 +1698,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1750,6 +1867,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1811,6 +1958,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1952,6 +2105,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2183,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2050,6 +2281,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ dirs = "6.0.0"
 env_logger = "0.11"
 indicatif = "0.18.2"
 log = "0.4"
+musli = { version = "0.0.149", features = ["json", "alloc"] }
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.9.8"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Commitbot
 
-A Rust-powered CLI that writes meaningful, structured Git commit messages using LLMs.</b>
-
+A Rust-powered CLI that writes meaningful, structured Git commit messages using LLMs.
 
 [![Version](https://img.shields.io/github/v/release/MikeGarde/commitbot?color=brightgreen&label=release)](https://github.com/MikeGarde/commitbot/releases)
 [![Version](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](https://github.com/MikeGarde/commitbot/blob/main/LICENSE)
@@ -16,11 +15,11 @@ It can summarize diffs, ask you how each file relates to the purpose of the comm
 
 ## Features
 
-- 🧩 **Interactive “ask” mode** – Classify each file as main, supporting, or consequential.
-- ⚡ **Quick mode** – Instantly summarize staged diffs into a commit message.
-- 🧠 **LLM-powered** – Uses OpenAI’s GPT models to generate concise and structured messages.
-- 🔧 **Configurable** – Choose models, tweak behavior, and set defaults in a config file.
-- 🧾 **Pull request summaries** – Generate clean, readable PR descriptions from your commit history.
+- **Interactive “ask” mode** – Classify each file as main, supporting, or consequential.
+- **Quick mode** – Instantly summarize staged diffs into a commit message.
+- **LLM-powered** – Uses OpenAI’s GPT models to generate concise and structured messages.
+- **Configurable** – Choose models, tweak behavior, and set defaults in a config file.
+- **Pull request summaries** – Generate clean, readable PR descriptions from your commit history.
 
 ---
 
@@ -32,37 +31,11 @@ You’ll need an OpenAI API key set as an environment variable:
 export OPENAI_API_KEY="sk-..."
 ```
 
-## Homebrew
+### Homebrew
 
 ```bash
 brew tap mikegarde/tap
 brew install commitbot
-```
-
-## Download a Prebuilt Binary
-
-1. Visit the [latest release](https://github.com/MikeGarde/commitbot/releases/latest).
-2. Download the binary for your platform.
-3. Make it executable and move it into your PATH:
-
-```bash
-chmod +x commitbot
-sudo mv commitbot /usr/local/bin/
-commitbot --version
-```
-## Rust/Cargo
-### Build from Source
-
-```bash
-git clone https://github.com/MikeGarde/commitbot.git
-cd commitbot
-cargo install --path . --force
-```
-
-### Install Directly from Git
-
-```bash
-cargo install --git https://github.com/MikeGarde/commitbot --force
 ```
 
 ---
@@ -119,8 +92,9 @@ Commitbot will:
 
 ## Configuration
 
-Commitbot looks for a configuration file at: [~/.config/commitbot.toml](./commitbot.toml). These settings are available 
-to CLI flags, environment variables, or even per-project config.
+Commitbot automatically loads its configuration from [~/.config/commitbot.toml](./commitbot.toml).
+Settings can be defined globally in this file, overridden by environment variables, or specified directly through CLI flags.
+Per-project configurations are also supported for repository-specific overrides.
 
 Example:
 
@@ -135,12 +109,10 @@ model = "gpt-5-nano"
 
 ## Roadmap
 
-- [ ] Support for local/offline LLMs (Ollama, LM Studio).
+- [x] Support for local/offline LLMs (Ollama, LM Studio).
 - [ ] Model auto-detection and fallback.
 - [ ] Configurable commit message templates.
 - [ ] Integration with GitHub Actions or CI pipelines.
-
----
 
 ## License
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,8 +1,5 @@
 version: '3'
 
-vars:
-  BINARY_NAME: commitbot
-
 tasks:
   setup:
     desc: "Setup development environment"
@@ -23,12 +20,12 @@ tasks:
   run:simple:
     desc: "Run commitbot in simple mode (no model, debug) using cargo run"
     cmds:
-      - cargo run -- --no-model --debug
+      - cargo run -- -vv
 
   run:ask:
     desc: "Run commitbot in interactive ask mode (no model, debug)"
     cmds:
-      - cargo run -- --ask --no-model --debug
+      - cargo run -- --ask
 
   run:ask:real:
     desc: "Run commitbot in interactive ask mode using real model"
@@ -42,7 +39,7 @@ tasks:
         fi
         cargo run -- --ask
 
-  install:local:
+  install:
     desc: "Install commitbot binary locally via cargo install --path ."
     cmds:
       - cargo install --path . --force
@@ -52,7 +49,7 @@ tasks:
     silent: true
     cmds:
       - cargo build --release
-      - du -h target/release/{{.BINARY_NAME}}
+      - du -h target/release/commitbot
 
   build:release:*:
     desc: "Build release binaries for all targets and package into dist/"
@@ -94,6 +91,7 @@ tasks:
       - sh devops/release.sh {{.VERSION}}
       - task: publish:dry
       - task: publish
+      - cd ../homebrew-tap && gh workflow run update-formula.yml -f formula=commitbot -f repo=mikegarde/commitbot -f version={{.VERSION}}
 
   publish:dry:
     desc: "Dry-run crates.io publish to verify packaging"

--- a/commitbot.toml
+++ b/commitbot.toml
@@ -1,22 +1,22 @@
 # ~/.config/commitbot.toml
 
-#######################################
-# Global defaults (used for all repos)
-#######################################
 [default]
-# Default model if nothing else is specified
+provider = "openai"
 model = "gpt-5-nano"
 
 # Optional: OpenAI-style API key (falls back to env OPENAI_API_KEY)
 openai_api_key = "your api key here"
 
+# Optional: provider base URL (e.g. http://localhost:11434 for Ollama)
+url = "https://api.openai.com"
+
 # 1 = fully serial, >1 = parallel API calls
 max_concurrent_requests = 4
 
-#######################################
-# Per-repo overrides
-#######################################
+
 ["mikegarde/commitbot"]
+provider = "openai"
+stream = false
 model = "gpt-4o-mini"
 openai_api_key = "alternative for spend identification"
 max_concurrent_requests = 8

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -32,9 +32,23 @@ pub struct Cli {
     #[arg(short = 'k', long, global = true)]
     pub api_key: Option<String>,
 
-    /// Optional: a brief human description of the ticket (for commit/PR summaries)
+    /// LLM provider / API style (openai or ollama)
     #[arg(long, global = true)]
-    pub ticket_summary: Option<String>,
+    pub provider: Option<String>,
+
+    /// Base URL for the selected provider (e.g. http://localhost:11434) llama3.1:8b-instruct-q5_K_M
+    #[arg(long, global = true)]
+    pub url: Option<String>,
+
+    /// Stream responses as they are generated (use `--stream=false` to disable)
+    #[arg(
+        long,
+        global = true,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub stream: Option<bool>,
 
     /// Increase verbosity (-v, -vv, -vvv)
     #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
@@ -64,4 +78,8 @@ pub enum Command {
         #[arg(long = "commit")]
         commit_mode: bool,
     },
+
+    /// Freeform summary provided at the end of the command.
+    #[command(external_subcommand)]
+    Summary(Vec<String>),
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,17 +9,20 @@ use git::detect_repo_id;
 /// Final resolved configuration for commitbot.
 #[derive(Debug, Clone)]
 pub struct Config {
-    pub openai_api_key: String,
+    pub provider: String,
+    pub openai_api_key: Option<String>,
+    pub base_url: Option<String>,
     pub model: String,
     pub max_concurrent_requests: usize,
+    pub stream: bool,
 }
 
 impl Config {
     /// Build the final config from CLI flags, environment, TOML file, and defaults.
     ///
     /// Precedence (highest to lowest):
-    ///   1. CLI flags (`--model`, `--api-key`, `--max`)
-    ///   2. Env vars (`COMMITBOT_MODEL`, `OPENAI_API_KEY`, `COMMITBOT_MAX_CONCURRENT_REQUESTS`)
+    ///   1. CLI flags (`--provider`, `--model`, `--api-key`, `--base-url`, `--max`, `--stream`)
+    ///   2. Env vars (`COMMITBOT_PROVIDER`, `COMMITBOT_MODEL`, `OPENAI_API_KEY`, `COMMITBOT_BASE_URL`, `COMMITBOT_MAX_CONCURRENT_REQUESTS`, `COMMITBOT_STREAM`)
     ///   3. Per-repo table in `~/.config/commitbot.toml` (e.g. ["mikegarde/commitbot"])
     ///   4. [default] table in `~/.config/commitbot.toml`
     ///   5. Hardcoded defaults (model = "gpt-5-nano", max_concurrent_requests = 4)
@@ -36,16 +39,32 @@ impl Config {
             .unwrap_or_default();
 
         // CLI values
+        let provider_cli = cli.provider.clone();
         let model_cli = cli.model.clone();
         let api_key_cli = cli.api_key.clone();
+        let base_url_cli = cli.url.clone();
         let max_cli = cli.max;
+        let stream_cli = cli.stream;
 
         // Env values
+        let provider_env = env::var("COMMITBOT_PROVIDER").ok();
         let model_env = env::var("COMMITBOT_MODEL").ok();
         let api_key_env = env::var("OPENAI_API_KEY").ok();
+        let base_url_env = env::var("COMMITBOT_BASE_URL").ok();
         let max_env = env::var("COMMITBOT_MAX_CONCURRENT_REQUESTS")
             .ok()
             .and_then(|s| s.parse::<usize>().ok());
+        let stream_env = env::var("COMMITBOT_STREAM")
+            .ok()
+            .and_then(|s| s.parse::<bool>().ok());
+
+        // Resolve provider
+        let provider = provider_cli
+            .or(provider_env)
+            .or(repo_file_cfg.provider)
+            .or(default_file_cfg.provider)
+            .unwrap_or_else(|| "openai".to_string())
+            .to_lowercase();
 
         // Resolve model
         let model = model_cli
@@ -54,12 +73,17 @@ impl Config {
             .or(default_file_cfg.model)
             .unwrap_or_else(|| "gpt-5-nano".to_string());
 
-        // Resolve API key (must exist somewhere)
+        // Resolve API key (only required for OpenAI-style providers)
         let openai_api_key = api_key_cli
             .or(api_key_env)
             .or(repo_file_cfg.openai_api_key)
-            .or(default_file_cfg.openai_api_key)
-            .expect("OPENAI_API_KEY must be set via CLI, env var, or config file");
+            .or(default_file_cfg.openai_api_key);
+
+        // Resolve base URL (used for ollama or openai-compatible endpoints)
+        let base_url = base_url_cli
+            .or(base_url_env)
+            .or(repo_file_cfg.base_url)
+            .or(default_file_cfg.base_url);
 
         // Resolve max concurrency; default to 4 if not specified anywhere
         let max_concurrent_requests = max_cli
@@ -68,20 +92,51 @@ impl Config {
             .or(default_file_cfg.max_concurrent_requests)
             .unwrap_or(4);
 
+        let stream = stream_cli
+            .or(stream_env)
+            .or(repo_file_cfg.stream)
+            .or(default_file_cfg.stream)
+            .unwrap_or(true);
+
+        let provider = provider.trim_matches('"').to_string();
+        let model = model.trim_matches('"').to_string();
+        let openai_api_key = openai_api_key.map(|s| s.trim_matches('"').to_string());
+        let base_url = base_url.map(|s| s.trim_matches('"').to_string());
+
+        let url = base_url.clone().unwrap_or_else(|| "".to_string());
+
+        log::debug!("Provider: {}", provider);
+        log::debug!("Model:    {}", model);
+        log::debug!("API key:  {}", openai_api_key.is_some());
+        log::debug!("URL:      {}", url);
+        log::debug!("Max Req:  {}", max_concurrent_requests);
+        log::debug!("Stream:   {}", stream);
+
+        if provider == "openai" && openai_api_key.is_none() {
+            panic!("OPENAI_API_KEY must be set via CLI, env var, or config file for provider=openai");
+        }
+
         Config {
+            provider,
             model,
             openai_api_key,
+            base_url,
             max_concurrent_requests,
+            stream,
         }
     }
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]
 struct FileConfig {
+    /// LLM provider / API style (openai or ollama).
+    pub provider: Option<String>,
     /// Default model to use when not provided via CLI or env.
     pub model: Option<String>,
     pub openai_api_key: Option<String>,
+    pub base_url: Option<String>,
     pub max_concurrent_requests: Option<usize>,
+    pub stream: Option<bool>,
 }
 
 /// Root of the TOML file:
@@ -110,4 +165,3 @@ fn load_file_config() -> Option<FileConfigRoot> {
     let data = fs::read_to_string(&path).ok()?;
     toml::from_str::<FileConfigRoot>(&data).ok()
 }
-

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,4 +1,8 @@
 pub mod openai;
+pub mod ollama;
+mod prompts;
+mod prompt_builder;
+mod stream;
 
 use crate::git::{PrItem, PrSummaryMode};
 use crate::FileChange;
@@ -27,6 +31,7 @@ pub trait LlmClient: Send + Sync {
         &self,
         branch: &str,
         diff: &str,
+        ticket_summary: Option<&str>,
     ) -> Result<String>;
 
     /// PR mode: generate a PR description from commit/PR messages.

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -1,0 +1,177 @@
+use anyhow::{anyhow, Result};
+use log;
+use musli::{Encode, Decode};
+use musli::json;
+use reqwest::blocking::Client;
+use std::io::BufReader;
+
+use crate::FileChange;
+use crate::git::{PrItem, PrSummaryMode};
+
+use super::{prompt_builder, LlmClient};
+use super::stream::read_stream_to_string;
+
+#[derive(Debug, Encode, Decode)]
+struct OllamaMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Encode, Decode)]
+struct OllamaChatResponse {
+    message: OllamaMessage,
+}
+
+#[derive(Debug, Decode)]
+struct OllamaStreamResponse {
+    message: Option<OllamaMessage>,
+    done: Option<bool>,
+}
+
+/// Synchronous Ollama client using /api/chat.
+pub struct OllamaClient {
+    http: Client,
+    base_url: String,
+    model: String,
+    stream: bool,
+}
+
+impl OllamaClient {
+    pub fn new(base_url: impl Into<String>, model: impl Into<String>, stream: bool) -> Self {
+        let http = Client::builder()
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            http,
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            model: model.into(),
+            stream,
+        }
+    }
+
+    /// Internal helper to talk to /api/chat.
+    fn chat(&self, system_prompt: String, user_prompt: String, stream: bool) -> Result<String> {
+        // Request structs we encode with musli::json.
+        #[derive(Debug, Encode)]
+        struct ChatMessage {
+            role: String,
+            content: String,
+        }
+
+        #[derive(Debug, Encode)]
+        struct ChatRequest {
+            model: String,
+            stream: bool,
+            messages: Vec<ChatMessage>,
+        }
+
+        let req_body = ChatRequest {
+            model: self.model.clone(),
+            stream,
+            messages: vec![
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: system_prompt,
+                },
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: user_prompt,
+                },
+            ],
+        };
+
+        let body_str = json::to_string(&req_body)
+            .map_err(|e| anyhow!("Failed to encode Ollama JSON request: {e}"))?;
+
+        log::trace!("Ollama request body: {body_str}");
+
+        let url = format!("{}/api/chat", self.base_url);
+
+        let resp = self
+            .http
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body_str)
+            .send()
+            .map_err(|e| anyhow!("Error calling Ollama at {url}: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow!("Ollama HTTP error from {url}: {e}"))?;
+
+        if stream {
+            let reader = BufReader::new(resp);
+            return read_stream_to_string(reader, |line| parse_stream_line(line));
+        }
+
+        let resp_text = resp
+            .text()
+            .map_err(|e| anyhow!("Failed to read Ollama response body: {e}"))?;
+
+        log::trace!("Ollama raw JSON response: {resp_text}");
+
+        let parsed: OllamaChatResponse =
+            json::from_str(&resp_text).map_err(|e| anyhow!("Failed to decode Ollama JSON: {e}"))?;
+
+        Ok(parsed.message.content.trim().to_string())
+    }
+
+}
+
+fn parse_stream_line(line: &str) -> Result<Option<String>> {
+    let parsed: OllamaStreamResponse =
+        json::from_str(line).map_err(|e| anyhow!("Failed to decode Ollama stream JSON: {e}"))?;
+
+    if parsed.done.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let content = parsed
+        .message
+        .and_then(|m| if m.content.is_empty() { None } else { Some(m.content) });
+
+    Ok(content)
+}
+
+impl LlmClient for OllamaClient {
+    fn summarize_file(
+        &self,
+        branch: &str,
+        file: &FileChange,
+        ticket_summary: Option<&str>,
+    ) -> Result<String> {
+        let prompts = prompt_builder::file_summary_prompt(branch, file, ticket_summary);
+        self.chat(prompts.system, prompts.user, false)
+    }
+
+    fn generate_commit_message(
+        &self,
+        branch: &str,
+        files: &[FileChange],
+        ticket_summary: Option<&str>,
+    ) -> Result<String> {
+        let prompts = prompt_builder::commit_message_prompt(branch, files, ticket_summary);
+        self.chat(prompts.system, prompts.user, self.stream)
+    }
+
+    fn generate_commit_message_simple(
+        &self,
+        branch: &str,
+        diff: &str,
+        ticket_summary: Option<&str>,
+    ) -> Result<String> {
+        let prompts = prompt_builder::commit_message_simple_prompt(branch, diff, ticket_summary);
+        self.chat(prompts.system, prompts.user, self.stream)
+    }
+
+    fn generate_pr_message(
+        &self,
+        base_branch: &str,
+        from_branch: &str,
+        mode: PrSummaryMode,
+        items: &[PrItem],
+        ticket_summary: Option<&str>,
+    ) -> Result<String> {
+        let prompts =
+            prompt_builder::pr_message_prompt(base_branch, from_branch, mode, items, ticket_summary);
+        self.chat(prompts.system, prompts.user, self.stream)
+    }
+}

--- a/src/llm/prompt_builder.rs
+++ b/src/llm/prompt_builder.rs
@@ -1,0 +1,198 @@
+use std::collections::BTreeMap;
+
+use crate::llm::prompts;
+use crate::{FileCategory, FileChange};
+use crate::git::{PrItem, PrSummaryMode};
+
+pub struct PromptPair {
+    pub system: String,
+    pub user: String,
+}
+
+pub fn file_summary_prompt(
+    branch: &str,
+    file: &FileChange,
+    ticket_summary: Option<&str>,
+) -> PromptPair {
+    let mut system = prompts::FILE_SUMMARY.to_owned();
+    if let Some(ts) = ticket_summary {
+        system.push_str("\nOverall ticket goal: ");
+        system.push_str(ts);
+    }
+
+    let user = format!(
+        "Branch: {branch}\n\
+         File: {path}\n\
+         Category: {category}\n\n\
+         Diff:\n\
+         ```diff\n{diff}\n```",
+        branch = branch,
+        path = file.path,
+        category = file.category.as_str(),
+        diff = file.diff
+    );
+
+    PromptPair { system, user }
+}
+
+pub fn commit_message_prompt(
+    branch: &str,
+    files: &[FileChange],
+    ticket_summary: Option<&str>,
+) -> PromptPair {
+    let mut system = prompts::SYSTEM_INSTRUCTIONS.to_owned();
+    if let Some(ts) = ticket_summary {
+        system.push_str("\nOverall ticket goal: ");
+        system.push_str(ts);
+    }
+
+    let per_file = render_per_file_summaries(files);
+    let user = format!(
+        "Branch: {branch}\n\nPer-file summaries:\n\n{per_file}",
+        branch = branch,
+        per_file = per_file
+    );
+
+    PromptPair { system, user }
+}
+
+pub fn commit_message_simple_prompt(
+    branch: &str,
+    diff: &str,
+    ticket_summary: Option<&str>,
+) -> PromptPair {
+    let mut system = prompts::SYSTEM_INSTRUCTIONS.to_owned();
+    if let Some(ts) = ticket_summary {
+        system.push_str("\nOverall ticket goal: ");
+        system.push_str(ts);
+    }
+
+    let user = format!(
+        "Branch: {branch}\n\nDiff:\n```diff\n{diff}\n```",
+        branch = branch,
+        diff = diff
+    );
+
+    PromptPair { system, user }
+}
+
+pub fn pr_message_prompt(
+    base_branch: &str,
+    from_branch: &str,
+    mode: PrSummaryMode,
+    items: &[PrItem],
+    ticket_summary: Option<&str>,
+) -> PromptPair {
+    let mut system = prompts::PR_INSTRUCTIONS.to_owned();
+    if let Some(ts) = ticket_summary {
+        system.push_str("\nOverall ticket goal: ");
+        system.push_str(ts);
+    }
+
+    let mut user = String::new();
+    user.push_str(&format!(
+        "Base branch: {base}\nFeature branch: {from}\nSummary mode: {mode}\n\n",
+        base = base_branch,
+        from = from_branch,
+        mode = mode.as_str()
+    ));
+
+    match mode {
+        PrSummaryMode::ByCommits => {
+            user.push_str("Commit history (oldest first):\n");
+            for item in items {
+                let short = item.commit_hash.chars().take(7).collect::<String>();
+                let pr_tag = item
+                    .pr_number
+                    .map(|n| format!(" (PR #{n})"))
+                    .unwrap_or_default();
+                user.push_str(&format!(
+                    "- {short}{pr_tag}: {title}\n",
+                    title = item.title.trim()
+                ));
+                if !item.body.trim().is_empty() {
+                    user.push_str("  Body:\n");
+                    user.push_str("  ");
+                    user.push_str(&item.body.replace('\n', "\n  "));
+                    user.push('\n');
+                }
+            }
+        }
+        PrSummaryMode::ByPrs => {
+            let mut grouped: BTreeMap<u32, Vec<&PrItem>> = BTreeMap::new();
+            let mut no_pr: Vec<&PrItem> = Vec::new();
+
+            for item in items {
+                if let Some(num) = item.pr_number {
+                    grouped.entry(num).or_default().push(item);
+                } else {
+                    no_pr.push(item);
+                }
+            }
+
+            user.push_str(
+                "Pull requests contributing to this branch (oldest commits first):\n",
+            );
+
+            for (num, group) in grouped {
+                let short = group[0]
+                    .commit_hash
+                    .chars()
+                    .take(7)
+                    .collect::<String>();
+                let title = group[0].title.trim();
+                user.push_str(&format!("\nPR #{num}: {title} [{short}]\n"));
+
+                if group.len() > 1 {
+                    user.push_str("Additional commits in this PR:\n");
+                    for item in group.iter().skip(1) {
+                        let sh = item
+                            .commit_hash
+                            .chars()
+                            .take(7)
+                            .collect::<String>();
+                        user.push_str(&format!(
+                            "- {sh}: {title}\n",
+                            title = item.title.trim()
+                        ));
+                    }
+                }
+            }
+
+            if !no_pr.is_empty() {
+                user.push_str(
+                    "\nCommits without associated PR numbers (may be small fixes or direct pushes):\n",
+                );
+                for item in no_pr {
+                    let short = item
+                        .commit_hash
+                        .chars()
+                        .take(7)
+                        .collect::<String>();
+                    user.push_str(&format!(
+                        "- {short}: {title}\n",
+                        title = item.title.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    PromptPair { system, user }
+}
+
+fn render_per_file_summaries(files: &[FileChange]) -> String {
+    let mut out = String::new();
+    for file in files.iter().filter(|f| !matches!(f.category, FileCategory::Ignored)) {
+        out.push_str(&format!(
+            "File: {path}\nCategory: {category}\nSummary:\n{summary}\n\n",
+            path = file.path,
+            category = file.category.as_str(),
+            summary = file
+                .summary
+                .as_deref()
+                .unwrap_or("[missing per-file summary]")
+        ));
+    }
+    out
+}

--- a/src/llm/prompts.rs
+++ b/src/llm/prompts.rs
@@ -1,0 +1,44 @@
+pub const FILE_SUMMARY: &str = r#"You are a helpful assistant that explains code changes
+file-by-file to later help generate a Git commit message.
+Rules:
+- Focus on intent, not line-by-line diffs.
+- Reading this summary should suplement reading the actual diff, not regurgitate it.
+- Do not repeat the code in human-readable form a reviewer will still read the code. You're intent
+  is to help the reviewer understand the intent of the change.
+- Keep the summary to an appropriate number of bullet points that is consistent with the size of the commit.
+- At this time you are unaware of any other files being changed;  it is unhelpful to mention unseen
+  changes, only consider this one."#;
+
+pub const SYSTEM_INSTRUCTIONS: &str = r#"You are a Git commit message assistant.
+Write a descriptive Git commit message based on the file summaries.
+Rules:
+1. Start with a summary line under 50 characters, no formatting.
+2. Follow with a detailed breakdown grouped by type of change.
+3. Use headlines (## Migrations, ## Factories, ## Models, etc.).
+4. Use bullet points under each group.
+5. If something is new, call it 'Introduced', not 'Refactored' unless it was refactored.
+6. If it fixes broken or incomplete behavior, prefer 'Fixed' or 'Refined'.
+7. Enclose functions, classes, filenames, and other code with `ticks`.
+8. Avoid generic terms like 'update' or 'improve' unless strictly accurate.
+9. Group repetitive changes (like renames) instead of repeating them per file,
+   or even reference the group a single time without listing every place they were changed.
+10. Focus on the main purpose and supporting work; only briefly mention consequences or ommit them
+   interally if they can be inferred from other changes. For example, don't mention importing a
+   module if also mentioning its usage."#;
+
+pub const PR_INSTRUCTIONS: &str = r#"You are a GitHub Pull Request description assistant.
+Your job is to summarize the *overall goal* of the branch and the important changes.
+Rules:
+1. Start with a concise PR title (<= 72 characters, no formatting).
+2. Then include sections, for example:
+   - ## Overview
+   - ## Changes
+   - ## Testing / Validation
+   - ## Notes / Risks
+3. Focus on user-visible behavior and domain-level intent, not line-by-line diffs.
+4. De-emphasize purely mechanical changes (formatting-only, CI-only, or style-only).
+5. If PR numbers are provided, reference them in the summary (e.g. 'PR #123').
+6. When multiple PRs contributed, explain how they fit together into a single story.
+7. Avoid generic phrases like 'misc changes' or 'small fixes'; be specific.
+8. In contradiction to point 7, if there are many small changes that don't merit
+   individual mention it's okay to summarize them briefly and together."#;

--- a/src/llm/stream.rs
+++ b/src/llm/stream.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use std::io::{self, BufRead, Write};
+
+/// Read a streaming response line-by-line, printing chunks as they arrive.
+pub fn read_stream_to_string<R, F>(reader: R, mut parse_line: F) -> Result<String>
+where
+    R: BufRead,
+    F: FnMut(&str) -> Result<Option<String>>,
+{
+    let mut out = String::new();
+    let mut stdout = io::stdout();
+
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(chunk) = parse_line(line)? {
+            out.push_str(&chunk);
+            print!("{}", chunk);
+            stdout.flush()?;
+        }
+    }
+
+    Ok(out)
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,13 +1,50 @@
-use log::debug;
 use crate::config::Config;
 use crate::llm::LlmClient;
 use crate::llm::openai::OpenAiClient;
+use crate::llm::ollama::OllamaClient;
 
 /// Build the LLM client based on CLI + config.
 pub fn build_llm_client(cfg: &Config) -> Box<dyn LlmClient> {
-    let key = cfg.openai_api_key.clone();
+    match cfg.provider.as_str() {
+        "openai" => {
+            let key = cfg
+                .openai_api_key
+                .clone()
+                .expect("OPENAI_API_KEY must be set for provider=openai");
+            let base_url = cfg
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.openai.com".to_string());
 
-    debug!("Using OpenAiClient with model: {}", cfg.model);
+            log::debug!(
+                "Using OpenAiClient with model: {} (stream={})",
+                cfg.model, cfg.stream
+            );
 
-    Box::new(OpenAiClient::new(key, cfg.model.clone()))
+            Box::new(OpenAiClient::new(
+                key,
+                cfg.model.clone(),
+                base_url,
+                cfg.stream,
+            ))
+        }
+        "ollama" => {
+            let base_url = cfg
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:11434".to_string());
+
+            log::debug!(
+                "Using OllamaClient with model: {} (stream={})",
+                cfg.model, cfg.stream
+            );
+
+            Box::new(OllamaClient::new(
+                base_url,
+                cfg.model.clone(),
+                cfg.stream,
+            ))
+        }
+        other => panic!("Unknown provider: {}", other),
+    }
 }


### PR DESCRIPTION
DEBUG Provider: openai
DEBUG Model:    gpt-5-nano
DEBUG API key:  true
DEBUG URL:
DEBUG Max Req:  4
DEBUG Stream:   true
DEBUG Using OpenAiClient with model: gpt-5-nano (stream=true)

----- Commit Message Preview -----
INFO  Streaming OpenAI model "gpt-5-nano"
DEBUG starting new connection: https://api.openai.com/ Add multi-provider LLM support (OpenAI/Ollama)

## New Components
- Introduced `src/llm/ollama.rs` implementing `OllamaClient` with streaming support.
- Introduced `src/llm/stream.rs` with `read_stream_to_string` to handle streaming responses.
- Introduced `src/llm/prompt_builder.rs` to assemble structured prompts from file diffs and items.
- Introduced `src/llm/prompts.rs` containing shared instruction constants (`FILE_SUMMARY`, `SYSTEM_INSTRUCTIONS`, `PR_INSTRUCTIONS`).
- Updated `src/llm/mod.rs` to export `pub mod ollama;` and include `prompts`, `prompt_builder`, `stream`.
- Updated `src/llm/openai.rs` to use `prompt_builder` for prompts and leverage streaming paths.

## CLI / Config
- Expanded CLI args in `src/cli_args.rs` to include:
  - `pub provider: Option<String>`, `pub url: Option<String>`, and `pub stream: Option<bool>`.
- Updated `commitbot.toml` to support per-repo config for `provider`, `base_url`, and `stream` with a per-repo override (`"mikegarde/commitbot"`).
- Updated `src/config.rs` to store:
  - `provider`, `openai_api_key`, `base_url`, `stream`, and `url` resolution with precedence rules.
  - Validation and debug logging for provider and URL.
- Modified `src/setup.rs` to build the LLM client based on `provider`:
  - Introduced branch for `"openai"` using `OpenAiClient` with `base_url` and `stream`.
  - Introduced branch for `"ollama"` using `OllamaClient` with `base_url` and `stream`.

## Features and Behavior
- Added multi-provider support to generate commit messages and PR descriptions:
  - OpenAI integration now uses `prompt_builder` and supports streaming via `read_stream_to_string`.
  - Ollama integration added with a synchronous chat method and optional streaming.
- Extended ticket summary handling:
  - Introduced `resolved_ticket_summary` in `src/main.rs` to support external subcommand `Summary`.

## Core Logic and Data Flow
- Refactored LLM client trait usage to accommodate new `provider`-driven flow and streaming:
  - `LlmClient` trait remains, now used by both `OpenAiClient` and `OllamaClient`.
  - OpenAI prompt generation and per-call streaming behavior updated to use `prompt_builder` and `prompts` constants.
- Centralized prompt construction:
  - `PromptPair` produced by `prompt_builder` feeds both system and user prompts to LLM calls.

## Config and TOML
- Updated `commitbot.toml` to define:
  - Global defaults and per-repo overrides for `provider`, `base_url`, `stream`.
  - Example per-repo: `["mikegarde/commitbot"]` with `provider`, `model`, `base_url`, etc.

## Documentation and Scripts
- Updated `README.md` to reflect new provider-agnostic flow and formatting of features.
- Updated `Taskfile.yaml` to adjust test/run commands and release steps (including Homebrew workflow trigger).

## Dependency and Build
- Updated `Cargo.toml` to introduce new LLM-related crates:
  - `musli`, `musli-core`, `musli-macros`, and `serde_json`.
- `Cargo.lock` updated accordingly to include new crates and versions.

## Files touched (highlights)
- New: `src/llm/ollama.rs`, `src/llm/stream.rs`, `src/llm/prompt_builder.rs`, `src/llm/prompts.rs`
- Updated: `src/llm/mod.rs`, `src/llm/openai.rs`, `src/cli_args.rs`, `src/config.rs`, `src/main.rs`, `src/setup.rs`
- New/Updated: `commitbot.toml`, `Taskfile.yaml`, `README.md`
- Dependency updates: `Cargo.toml`, `Cargo.lock`

----------------------------------

DEBUG Provider: ollama
DEBUG Model:    llama3.1:8b-instruct-q5_K_M
DEBUG API key:  true
DEBUG URL:      http://192.168.1.16:11434
DEBUG Max Req:  4
DEBUG Stream:   true
DEBUG Using OllamaClient with model: llama3.1:8b-instruct-q5_K_M (stream=true)

----- Commit Message Preview -----
DEBUG starting new connection: http://192.168.1.16:11434/ This code is a significant refactoring of the commitbot project, specifically focusing on improving the LLN (Large Language Model) integration. Here's a high-level summary of the changes:

**New Features**

1. **Streaming support**: The `LlmClient` trait now includes a new method `generate_streaming_result`, which allows clients to generate streaming results instead of returning a single string.
2. **Configurable stream mode**: A new field `stream` has been added to the `Config` struct, allowing users to enable or disable streaming mode for their LLN client.

**Refactored LLN Clients**

1. **OpenAiClient**: The OpenAI client has been refactored to support streaming mode. It now takes an additional `base_url` parameter and a `stream` flag.
2. **OllamaClient**: A new Ollama client has been added, which supports both synchronous and asynchronous (streaming) modes.

**Changes in the Main Function**

1. **Configurable LLN provider**: The main function now takes an optional `cfg.provider` field, allowing users to specify a different LLN provider (e.g., "ollama").
2. **Stream mode detection**: The main function now checks if streaming mode is enabled for the current LLN client and adjusts its behavior accordingly.

**Other Changes**

1. **Improved error handling**: The code now uses `anyhow` for error handling, making it easier to handle errors in a more robust way.
2. **Simplified CLI arguments**: The `run_interactive` function now takes fewer CLI arguments, as the streaming mode is determined automatically based on the LLN client configuration.

Overall, this refactoring aims to make the commitbot project more flexible and efficient by supporting multiple LLN providers and enabling streaming mode for improved performance.