### PR TITLE
Refactor stream parsing

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -88,6 +88,7 @@ tasks:
       VERSION: '{{index .MATCH 0}}'
     interactive: true
     cmds:
+      - task: test
       - sh devops/release.sh {{.VERSION}}
       - task: publish:dry
       - task: publish

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,7 @@ impl Config {
         let openai_api_key = openai_api_key.map(|s| s.trim_matches('"').to_string());
         let base_url = base_url.map(|s| s.trim_matches('"').to_string());
 
-        let url = base_url.clone().unwrap_or_else(|| "".to_string());
+        let url = base_url.clone().unwrap_or_default();
 
         log::debug!("Provider: {}", provider);
         log::debug!("Model:    {}", model);

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -99,7 +99,7 @@ impl OllamaClient {
 
         if stream {
             let reader = BufReader::new(resp);
-            return read_stream_to_string(reader, |line| parse_stream_line(line));
+            return read_stream_to_string(reader, parse_stream_line);
         }
 
         let resp_text = resp

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -161,7 +161,7 @@ impl OpenAiClient {
         }
 
         let reader = BufReader::new(resp);
-        read_stream_to_string(reader, |line| parse_stream_line(line))
+        read_stream_to_string(reader, parse_stream_line)
     }
 }
 


### PR DESCRIPTION
## Config
- Refactored default URL handling in `src/config.rs` to use `unwrap_or_default()` instead of `unwrap_or_else(|| "".to_string())`.

## Refactors
- Refactored `src/llm/ollama.rs` to pass `parse_stream_line` directly to `read_stream_to_string` instead of using a closure.
- Refactored `src/llm/openai.rs` to pass `parse_stream_line` directly to `read_stream_to_string` instead of using a closure.