### PR TITLE
Cleanup: remove deprecated CLI flag and dead code

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -12,10 +12,6 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub ask: bool,
 
-    /// If set, write the generated message into .git/COMMIT_EDITMSG (no commit is created)
-    #[arg(short = 'w', long, global = true)]
-    pub apply: bool,
-
     /// Stage all changes before generating the commit message
     #[arg(short, long, global = true)]
     pub stage: bool,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,7 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use std::path::PathBuf;
 use std::process::Command as GitCommand;
-use std::fs;
 
 /// How we want to summarize a PR.
 #[derive(Debug, Clone, Copy)]
@@ -44,34 +42,6 @@ pub fn git_output(args: &[&str]) -> Result<String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-/// Get the path to the Git directory (e.g. .git)
-pub fn git_dir() -> Result<PathBuf> {
-    let output = GitCommand::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output()
-        .context("failed to run git rev-parse --git-dir")?;
-
-    if !output.status.success() {
-        return Err(anyhow!(
-            "git rev-parse --git-dir exited with status {:?}",
-            output.status.code()
-        ));
-    }
-
-    let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(PathBuf::from(dir))
-}
-
-/// Write the commit message into .git/COMMIT_EDITMSG so the next `git commit`
-/// will use it as the default message in the editor.
-pub fn write_commit_editmsg(message: &str) -> Result<()> {
-    let dir = git_dir()?;
-    let path = dir.join("COMMIT_EDITMSG");
-    fs::write(&path, message)
-        .with_context(|| format!("failed to write commit message to {:?}", path))?;
-    Ok(())
 }
 
 /// Get the current branch name.


### PR DESCRIPTION
- CLI
  - Removed `-w` apply flag from `src/cli_args.rs`, eliminating the ability to write the generated message to `.git/COMMIT_EDITMSG` without creating a commit. Preserved the existing stage option and other flags to maintain CLI surface.

- Git
  - Removed `git_dir` and `write_commit_editmsg` helpers from `src/git.rs`, plus unused imports `PathBuf` and `fs`. Preserved `git_output` and the current-branch derivation via `git rev-parse --abbrev-ref HEAD`.

- Main UI
  - Refactored per-file progress UI with `MultiProgress` and per-file spinner lines showing status; added final summary snippet or error. Introduced formatting helpers `preview_snippet` and `dimmed`.
  - Introduced optional per-file progress updates in `summarize_files_concurrently` to reflect results as they arrive.
  - In `run_interactive` wiring, created a line per file (spinner progress bars) and a main progress bar; passed lines to the summarization routine and updated them as results arrived; marked ignored upfront and animated the waiting state for others; displayed a final “Done” message after all files are summarized.
  - Removed the previous commit-edit/auto-apply flow for interactive and simple modes; for both paths, generate and print the commit/PR messages without writing to `.git/COMMIT_EDITMSG` or applying changes, and drop extra banner wrappers around previews.
  - Minor import and formatting cleanup to support the new UI (Duration, `MultiProgress`, `ProgressStyle`).