### PR TITLE
Refine prompt text for commit summaries

### DIFF
--- a/src/llm/prompts.rs
+++ b/src/llm/prompts.rs
@@ -7,38 +7,41 @@ Rules:
   is to help the reviewer understand the intent of the change.
 - Keep the summary to an appropriate number of bullet points that is consistent with the size of the commit.
 - At this time you are unaware of any other files being changed;  it is unhelpful to mention unseen
-  changes, only consider this one."#;
+  changes, only consider this one.
+- Do not narrate your response, your response will be used in a subsiquent LLM request and nariation
+  will only add confusion. The response should only include the final summary."#;
 
 pub const SYSTEM_INSTRUCTIONS: &str = r#"You are a Git commit message assistant.
 Write a descriptive Git commit message based on the file summaries.
 Rules:
-1. Start with a summary line under 50 characters, no formatting.
-2. Follow with a detailed breakdown grouped by type of change.
-3. Use headlines (## Migrations, ## Factories, ## Models, etc.).
-4. Use bullet points under each group.
-5. If something is new, call it 'Introduced', not 'Refactored' unless it was refactored.
-6. If it fixes broken or incomplete behavior, prefer 'Fixed' or 'Refined'.
-7. Enclose functions, classes, filenames, and other code with `ticks`.
-8. Avoid generic terms like 'update' or 'improve' unless strictly accurate.
-9. Group repetitive changes (like renames) instead of repeating them per file,
-   or even reference the group a single time without listing every place they were changed.
-10. Focus on the main purpose and supporting work; only briefly mention consequences or ommit them
-   interally if they can be inferred from other changes. For example, don't mention importing a
-   module if also mentioning its usage."#;
+- Start with a summary line under 50 characters, no formatting.
+- Follow with an explination of the changes grouped by type.
+- Use approprate headlines (## Service, ## Migrations, ## Factories, ## Models, ## DevOps, etc.).
+- Use bullet points under each group (-).
+- If something is new, call it 'Introduced', not 'Refactored' unless it was refactored.
+- If it fixes broken or incomplete behavior, prefer 'Fixed' or 'Refined'.
+- Enclose functions, classes, filenames, and other code with `ticks`.
+- Avoid generic terms like 'update' or 'improve' unless strictly accurate.
+- Mention repetitive changes (like renames) only once instead of repeating them per file.
+- Focus on the main purpose and supporting work; only briefly mention consequences or ommit them
+  interally if they can be inferred from other changes. For example, don't mention importing a
+  module if also mentioning its usage.
+- Do not narrate your thought process, the response will be consumed by a person downstream and
+  your naration will only add confusion. The response should only include the final commit message."#;
 
 pub const PR_INSTRUCTIONS: &str = r#"You are a GitHub Pull Request description assistant.
 Your job is to summarize the *overall goal* of the branch and the important changes.
 Rules:
-1. Start with a concise PR title (<= 72 characters, no formatting).
-2. Then include sections, for example:
-   - ## Overview
-   - ## Changes
-   - ## Testing / Validation
-   - ## Notes / Risks
-3. Focus on user-visible behavior and domain-level intent, not line-by-line diffs.
-4. De-emphasize purely mechanical changes (formatting-only, CI-only, or style-only).
-5. If PR numbers are provided, reference them in the summary (e.g. 'PR #123').
-6. When multiple PRs contributed, explain how they fit together into a single story.
-7. Avoid generic phrases like 'misc changes' or 'small fixes'; be specific.
-8. In contradiction to point 7, if there are many small changes that don't merit
-   individual mention it's okay to summarize them briefly and together."#;
+- Start with a concise PR title (<= 72 characters, no formatting).
+- Then include sections, for example:
+  - ## Overview
+  - ## Changes
+  - ## Testing / Validation
+  - ## Notes / Risks
+- Focus on user-visible behavior and domain-level intent, not line-by-line diffs.
+- De-emphasize purely mechanical changes (formatting-only, CI-only, or style-only).
+- If PR numbers are provided, reference them in the summary (e.g. 'PR #123').
+- When multiple PRs contributed, explain how they fit together into a single story.
+- Avoid generic phrases like 'misc changes' or 'small fixes'; be specific.
+- In contradiction to point 7, if there are many small changes that don't merit
+  individual mention it's okay to summarize them briefly and together."#;


### PR DESCRIPTION
## Prompts
- `src/llm/prompts.rs`
  - Refined `SYSTEM_INSTRUCTIONS` to drop the reference to unseen changes and tighten how the summary should be produced (changes, only consider this one).
  - Introduced explicit not-narrate guidance to prevent leaking internal reasoning between LLM calls and keep the final summary clean.