### PR TITLE
Release ordering for CI/CD publishing

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Check out tagged source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.meta.outputs.tag }}
 
@@ -133,12 +133,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ steps.meta.outputs.tag }}" "$ASSET_PATH" --clobber
 
-      - name: Publish release if all assets are present
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        shell: bash
-        run: bash devops/publish-if-complete.sh "${{ steps.meta.outputs.tag }}"
-
       - name: Add run summary
         shell: bash
         run: |
@@ -151,3 +145,20 @@ jobs:
               echo "- Triggered by: ${{ inputs.source_run_url }}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-release:
+    name: Publish release
+    needs: build-release-assets
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Publish release and trigger Homebrew tap update
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: bash devops/publish-if-complete.sh "${{ inputs.tag }}"

--- a/devops/publish-if-complete.sh
+++ b/devops/publish-if-complete.sh
@@ -28,7 +28,7 @@ gh release edit "${TAG}" --draft=false
 echo "Published."
 
 echo "Triggering Homebrew tap formula update..."
-if gh workflow run update-formula.yml \
+if GH_TOKEN="${HOMEBREW_TAP_TOKEN:-}" gh workflow run update-formula.yml \
   --repo MikeGarde/homebrew-tap \
   -f formula=commitbot \
   -f repo=MikeGarde/commitbot \

--- a/devops/render-release-notes.sh
+++ b/devops/render-release-notes.sh
@@ -21,9 +21,9 @@ cat <<EOF
 | RHEL** | [Download]($(asset_url "commitbot-${VERSION}-aarch64-unknown-linux-musl.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-x86_64-unknown-linux-musl.tar.gz")) |
 | Windows*** | — | [Download]($(asset_url "commitbot-${VERSION}-x86_64-pc-windows-gnu.zip")) |
 
-* Ubuntu and compatible distributions like Debian, Mint, etc. that use glibc.
-** RHEL and compatible distributions like Amazon, Rocky, etc. that use musl instead of glibc.
-*** Windows x86_64 only; built with the GNU toolchain (mingw-w64).
+\* Ubuntu and compatible distributions like Debian, Mint, etc. that use glibc.
+\** RHEL and compatible distributions like Amazon, Rocky, etc. that use musl instead of glibc.
+\*** Windows x86_64 only; built with the GNU toolchain (mingw-w64).
 
 EOF
 


### PR DESCRIPTION
- Refactor release assets workflow:
  - Updated dependency versions for `actions/checkout`.
  - Centralized logic for publishing releases and updating Homebrew tap.
- Secure publish script:
  - Mandated explicit use of `HOMEBREW_TAP_TOKEN` in `publish-if-complete.sh`.
- Fix release notes formatting:
  - Adjusted markdown markers in `render-release-notes.sh` from hyphens to escaped asterisks.