### PR TITLE
Standardize release artifact naming conventions

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -35,6 +35,7 @@ jobs:
           - name: Linux arm64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            asset_target: unknown-linux-gnu-aarch64
             archive_ext: tar.gz
             binary_name: commitbot
             install_cmd: ""
@@ -42,6 +43,7 @@ jobs:
           - name: Linux x86_64
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            asset_target: unknown-linux-gnu-x86_64
             archive_ext: tar.gz
             binary_name: commitbot
             install_cmd: ""
@@ -49,6 +51,7 @@ jobs:
           - name: Amazon Linux / CentOS / RHEL arm64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+            asset_target: unknown-linux-musl-aarch64
             archive_ext: tar.gz
             binary_name: commitbot
             install_cmd: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -56,6 +59,7 @@ jobs:
           - name: Amazon Linux / CentOS / RHEL x86_64
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+            asset_target: unknown-linux-musl-x86_64
             archive_ext: tar.gz
             binary_name: commitbot
             install_cmd: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -63,6 +67,7 @@ jobs:
           - name: Windows x86_64
             runner: ubuntu-24.04
             target: x86_64-pc-windows-gnu
+            asset_target: pc-windows-gnu-x86_64
             archive_ext: zip
             binary_name: commitbot.exe
             install_cmd: sudo apt-get update && sudo apt-get install -y mingw-w64
@@ -113,7 +118,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.target }}.tar.gz"
+          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.tar.gz"
           tar -C "target/${{ matrix.target }}/release" -czf "$asset" "${{ matrix.binary_name }}"
           echo "ASSET_PATH=$asset" >> "$GITHUB_ENV"
 
@@ -122,7 +127,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.target }}.zip"
+          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.zip"
           cd "target/${{ matrix.target }}/release"
           zip "../../../${asset}" "${{ matrix.binary_name }}"
           cd -

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -98,11 +98,11 @@ tasks:
         echo "Packaging into dist with version {{.VERSION}}..."
 
         tar -C target/aarch64-apple-darwin/release \
-          -czf dist/commitbot-{{.VERSION}}-aarch64-apple-darwin.tar.gz \
+          -czf dist/commitbot-{{.VERSION}}-apple-darwin-aarch64.tar.gz \
           commitbot
 
         tar -C target/x86_64-apple-darwin/release \
-          -czf dist/commitbot-{{.VERSION}}-x86_64-apple-darwin.tar.gz \
+          -czf dist/commitbot-{{.VERSION}}-apple-darwin-x86_64.tar.gz \
           commitbot
 
         echo "Artifacts created:"

--- a/devops/publish-if-complete.sh
+++ b/devops/publish-if-complete.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 TAG="${1:?usage: publish-if-complete.sh <tag>}"
 
 EXPECTED=(
-  "commitbot-${TAG}-aarch64-apple-darwin.tar.gz"
-  "commitbot-${TAG}-x86_64-apple-darwin.tar.gz"
-  "commitbot-${TAG}-aarch64-unknown-linux-gnu.tar.gz"
-  "commitbot-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
-  "commitbot-${TAG}-aarch64-unknown-linux-musl.tar.gz"
-  "commitbot-${TAG}-x86_64-unknown-linux-musl.tar.gz"
-  "commitbot-${TAG}-x86_64-pc-windows-gnu.zip"
+  "commitbot-${TAG}-apple-darwin-aarch64.tar.gz"
+  "commitbot-${TAG}-apple-darwin-x86_64.tar.gz"
+  "commitbot-${TAG}-unknown-linux-gnu-aarch64.tar.gz"
+  "commitbot-${TAG}-unknown-linux-gnu-x86_64.tar.gz"
+  "commitbot-${TAG}-unknown-linux-musl-aarch64.tar.gz"
+  "commitbot-${TAG}-unknown-linux-musl-x86_64.tar.gz"
+  "commitbot-${TAG}-pc-windows-gnu-x86_64.zip"
 )
 
 ACTUAL="$(gh release view "${TAG}" --json assets --jq '[.assets[].name]')"

--- a/devops/render-release-notes.sh
+++ b/devops/render-release-notes.sh
@@ -16,10 +16,10 @@ cat <<EOF
 
 | OS | arm64 | x86_64 |
 | --- | --- | --- |
-| macOS | [Download]($(asset_url "commitbot-${VERSION}-aarch64-apple-darwin.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-x86_64-apple-darwin.tar.gz")) |
-| Ubuntu* | [Download]($(asset_url "commitbot-${VERSION}-aarch64-unknown-linux-gnu.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-x86_64-unknown-linux-gnu.tar.gz")) |
-| RHEL** | [Download]($(asset_url "commitbot-${VERSION}-aarch64-unknown-linux-musl.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-x86_64-unknown-linux-musl.tar.gz")) |
-| Windows*** | — | [Download]($(asset_url "commitbot-${VERSION}-x86_64-pc-windows-gnu.zip")) |
+| macOS | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-x86_64.tar.gz")) |
+| Ubuntu* | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-x86_64.tar.gz")) |
+| RHEL** | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-x86_64.tar.gz")) |
+| Windows*** | — | [Download]($(asset_url "commitbot-${VERSION}-pc-windows-gnu-x86_64.zip")) |
 
 \* Ubuntu and compatible distributions like Debian, Mint, etc. that use glibc.
 \** RHEL and compatible distributions like Amazon, Rocky, etc. that use musl instead of glibc.


### PR DESCRIPTION
- Update CI workflows (`release-assets.yml`) to use explicit `asset_target` definitions for asset packaging.
- Refactor build scripts and tasks to standardize artifact filenames, enforcing OS-before-arch order in all generated names.
- Adjust validation and documentation scripts to consume the new standardized naming format.