### PR TITLE
Use gzip compression for release artifacts

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -36,7 +36,7 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             asset_target: unknown-linux-gnu-aarch64
-            archive_ext: tar.gz
+            archive_ext: gz
             binary_name: commitbot
             install_cmd: ""
             linker: ""
@@ -44,7 +44,7 @@ jobs:
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             asset_target: unknown-linux-gnu-x86_64
-            archive_ext: tar.gz
+            archive_ext: gz
             binary_name: commitbot
             install_cmd: ""
             linker: ""
@@ -52,7 +52,7 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             asset_target: unknown-linux-musl-aarch64
-            archive_ext: tar.gz
+            archive_ext: gz
             binary_name: commitbot
             install_cmd: sudo apt-get update && sudo apt-get install -y musl-tools
             linker: musl-gcc
@@ -60,7 +60,7 @@ jobs:
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             asset_target: unknown-linux-musl-x86_64
-            archive_ext: tar.gz
+            archive_ext: gz
             binary_name: commitbot
             install_cmd: sudo apt-get update && sudo apt-get install -y musl-tools
             linker: musl-gcc
@@ -113,13 +113,13 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'x86_64-unknown-linux-musl' && matrix.linker || '' }}
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Package tar.gz archive
-        if: matrix.archive_ext == 'tar.gz'
+      - name: Compress release binary
+        if: matrix.archive_ext == 'gz'
         shell: bash
         run: |
           set -euo pipefail
-          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.tar.gz"
-          tar -C "target/${{ matrix.target }}/release" -czf "$asset" "${{ matrix.binary_name }}"
+          asset="commitbot-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.gz"
+          gzip -n -c "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" > "$asset"
           echo "ASSET_PATH=$asset" >> "$GITHUB_ENV"
 
       - name: Package zip archive

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -84,7 +84,7 @@ tasks:
     silent: true
     cmds:
       - mkdir -p dist
-      - rm -f dist/commitbot-*.tar.gz
+      - rm -f dist/commitbot-*.gz
       - |
         set -euo pipefail
 
@@ -97,13 +97,11 @@ tasks:
 
         echo "Packaging into dist with version {{.VERSION}}..."
 
-        tar -C target/aarch64-apple-darwin/release \
-          -czf dist/commitbot-{{.VERSION}}-apple-darwin-aarch64.tar.gz \
-          commitbot
+        gzip -n -c target/aarch64-apple-darwin/release/commitbot \
+          > dist/commitbot-{{.VERSION}}-apple-darwin-aarch64.gz
 
-        tar -C target/x86_64-apple-darwin/release \
-          -czf dist/commitbot-{{.VERSION}}-apple-darwin-x86_64.tar.gz \
-          commitbot
+        gzip -n -c target/x86_64-apple-darwin/release/commitbot \
+          > dist/commitbot-{{.VERSION}}-apple-darwin-x86_64.gz
 
         echo "Artifacts created:"
         ls -lh dist

--- a/devops/publish-if-complete.sh
+++ b/devops/publish-if-complete.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 TAG="${1:?usage: publish-if-complete.sh <tag>}"
 
 EXPECTED=(
-  "commitbot-${TAG}-apple-darwin-aarch64.tar.gz"
-  "commitbot-${TAG}-apple-darwin-x86_64.tar.gz"
-  "commitbot-${TAG}-unknown-linux-gnu-aarch64.tar.gz"
-  "commitbot-${TAG}-unknown-linux-gnu-x86_64.tar.gz"
-  "commitbot-${TAG}-unknown-linux-musl-aarch64.tar.gz"
-  "commitbot-${TAG}-unknown-linux-musl-x86_64.tar.gz"
+  "commitbot-${TAG}-apple-darwin-aarch64.gz"
+  "commitbot-${TAG}-apple-darwin-x86_64.gz"
+  "commitbot-${TAG}-unknown-linux-gnu-aarch64.gz"
+  "commitbot-${TAG}-unknown-linux-gnu-x86_64.gz"
+  "commitbot-${TAG}-unknown-linux-musl-aarch64.gz"
+  "commitbot-${TAG}-unknown-linux-musl-x86_64.gz"
   "commitbot-${TAG}-pc-windows-gnu-x86_64.zip"
 )
 

--- a/devops/release.sh
+++ b/devops/release.sh
@@ -123,7 +123,7 @@ if git rev-parse -q --verify "refs/tags/$NEW_VERSION" >/dev/null 2>&1; then
   task setup
   task "build:release:${NEW_VERSION}"
 
-  MAC_ASSETS=("$DIST_DIR"/commitbot-"$NEW_VERSION"-*apple-darwin*.tar.gz)
+  MAC_ASSETS=("$DIST_DIR"/commitbot-"$NEW_VERSION"-*apple-darwin*.gz)
   if [ ${#MAC_ASSETS[@]} -eq 0 ]; then
     echo "Error: no Mac assets found in $DIST_DIR after build."
     exit 1
@@ -212,7 +212,7 @@ if [ ! -d "$DIST_DIR" ]; then
   exit 1
 fi
 
-MAC_ASSETS=("$DIST_DIR"/commitbot-"$NEW_VERSION"-*apple-darwin*.tar.gz)
+MAC_ASSETS=("$DIST_DIR"/commitbot-"$NEW_VERSION"-*apple-darwin*.gz)
 if [ ${#MAC_ASSETS[@]} -eq 0 ]; then
   echo "Error: no Mac assets found in '$DIST_DIR'."
   exit 1

--- a/devops/render-release-notes.sh
+++ b/devops/render-release-notes.sh
@@ -16,9 +16,9 @@ cat <<EOF
 
 | OS | arm64 | x86_64 |
 | --- | --- | --- |
-| macOS | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-x86_64.tar.gz")) |
-| Ubuntu* | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-x86_64.tar.gz")) |
-| RHEL** | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-aarch64.tar.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-x86_64.tar.gz")) |
+| macOS | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-aarch64.gz")) | [Download]($(asset_url "commitbot-${VERSION}-apple-darwin-x86_64.gz")) |
+| Ubuntu* | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-aarch64.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-gnu-x86_64.gz")) |
+| RHEL** | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-aarch64.gz")) | [Download]($(asset_url "commitbot-${VERSION}-unknown-linux-musl-x86_64.gz")) |
 | Windows*** | — | [Download]($(asset_url "commitbot-${VERSION}-pc-windows-gnu-x86_64.zip")) |
 
 \* Ubuntu and compatible distributions like Debian, Mint, etc. that use glibc.
@@ -28,7 +28,8 @@ cat <<EOF
 ## Install on Amazon Linux
 
 ~~~sh
-curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-\$(uname -m).tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin commitbot
+curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-\$(uname -m).gz" | gunzip | sudo tee /usr/local/bin/commitbot > /dev/null
+sudo chmod +x /usr/local/bin/commitbot
 ~~~
 
 EOF


### PR DESCRIPTION
- Replace `tar.gz` with direct `gzip` in the release workflow and `Taskfile.yaml`.
- Update artifact naming and search patterns in publishing and release scripts.
- Adjust release notes to reflect new binary names and installation instructions. 

Token usage: prompt=3369, completion=1584, total=4953