### PR TITLE
Include provider and model in token usage feedback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn run_interactive(cli: &Cli, cfg: &Config, llm: &dyn LlmClient) -> Result<()> {
 
     println!();
     if let Some((p, c, t)) = llm.take_and_reset_usage() {
-        print!("\n");
+        println!();
         println!("Provider: {} {}", cfg.provider, cfg.model );
         println!("Tokens:   prompt={}, completion={}, total={}", p, c, t);
     }
@@ -573,7 +573,7 @@ fn run_auto(cli: &Cli, cfg: &Config, llm: &dyn LlmClient) -> Result<()> {
 
     println!();
     if let Some((p, c, t)) = llm.take_and_reset_usage() {
-        print!("\n");
+        println!();
         println!("Provider: {} {}", cfg.provider, cfg.model );
         println!("Tokens:   prompt={}, completion={}, total={}", p, c, t);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,9 @@ fn run_interactive(cli: &Cli, cfg: &Config, llm: &dyn LlmClient) -> Result<()> {
 
     println!();
     if let Some((p, c, t)) = llm.take_and_reset_usage() {
-        println!("Token usage: prompt={}, completion={}, total={}", p, c, t);
+        print!("\n");
+        println!("Provider: {} {}", cfg.provider, cfg.model );
+        println!("Tokens:   prompt={}, completion={}, total={}", p, c, t);
     }
 
     Ok(())
@@ -571,7 +573,9 @@ fn run_auto(cli: &Cli, cfg: &Config, llm: &dyn LlmClient) -> Result<()> {
 
     println!();
     if let Some((p, c, t)) = llm.take_and_reset_usage() {
-        println!("Token usage: prompt={}, completion={}, total={}", p, c, t);
+        print!("\n");
+        println!("Provider: {} {}", cfg.provider, cfg.model );
+        println!("Tokens:   prompt={}, completion={}, total={}", p, c, t);
     }
 
     Ok(())


### PR DESCRIPTION
- Add provider and model details to token usage feedback.

Provider: lmstudio google/gemma-4-12b-qat
Tokens:   prompt=499, completion=283, total=782